### PR TITLE
Fix for objectids in bson encoder/decoder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
     evaluationDependsOn(':util')
 
     group = 'org.mongodb'
-    version = '3.2.2'
+    version = '3.2.2-textiq'
     sourceCompatibility = JavaVersion.VERSION_1_6
     targetCompatibility = JavaVersion.VERSION_1_6
 


### PR DESCRIPTION
If an `_id` cannot be parsed as an `ObjectId`, fall back to `String`. This allows for `_id` fields that do not store an `ObjectId`.